### PR TITLE
[Security advisory] Accepts only tokens issued by own org

### DIFF
--- a/iam_workload_identity_pool.tf
+++ b/iam_workload_identity_pool.tf
@@ -13,6 +13,8 @@ resource "google_iam_workload_identity_pool_provider" "github_actions" {
     "attribute.repository" = "assertion.repository"
   }
 
+  attribute_condition = "assertion.repository_owner == '${var.github_username}'"
+
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }

--- a/modules/workload_identity/iam_workload_identity_pool.tf
+++ b/modules/workload_identity/iam_workload_identity_pool.tf
@@ -13,6 +13,8 @@ resource "google_iam_workload_identity_pool_provider" "github_actions" {
     "attribute.repository" = "assertion.repository"
   }
 
+  attribute_condition = "assertion.repository_owner == '${var.github_username}'"
+
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }


### PR DESCRIPTION
ref. https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#conditions